### PR TITLE
settings window cleaning

### DIFF
--- a/src/acf_outline.c
+++ b/src/acf_outline.c
@@ -35,7 +35,7 @@
             sizeof (path)); \
         str = acf_prop_find(acf, path); \
         if (str == NULL) { \
-            logMsg(BP_ERROR_LOG "Error parsing acf file: property %s not found",\
+            logMsg(BP_INFO_LOG "Cannot parse acf file: property %s not found, aircraft outline may not well drawn",\
                 path); \
             goto errout; \
         } \

--- a/src/bp.c
+++ b/src/bp.c
@@ -1861,7 +1861,7 @@ pb_step_lift(void) {
     if (d_t >= PB_CONN_LIFT_DURATION + STATE_TRANS_DELAY) {
         if (late_plan_requested) {
             /*
-             * The user requsted a late plan, so this is as
+             * The user requested a late plan, so this is as
              * far as we can go without segments. Also wait
              * for the camera to stop.
              */

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -439,7 +439,7 @@ create_main_window(void) {
         buttons.var = create_widget_rel(x, y, B_FALSE, w, h, 1, \
             label, 0, main_win, xpWidgetClass_Button); \
         if (tooltip != NULL) { \
-         /*   tooltip_new(tts, x, y, w, h, _(tooltip));  */ \
+            tooltip_new(tts, x, y, w, h, _(tooltip));   \
         } \
     } while (0)
 

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -106,8 +106,7 @@ const char *disco_when_done_tooltip =
         "the tug when the pushback operation is complete.";
 const char *hide_xp11_tug_tooltip =
         "Hides default X-Plane 11 pushback tug.\n"
-        "Restart X-Plane for this change to take effect.\n"
-        "This operation is not supported on X-Plane 12.";
+        "Restart X-Plane for this change to take effect.";
 
 static void
 buttons_update(void) {
@@ -119,7 +118,7 @@ buttons_update(void) {
 
     (void) conf_get_str(bp_conf, "lang", &lang);
     (void) conf_get_b(bp_conf, "disco_when_done", &disco_when_done);
-    (void) conf_get_b(bp_conf, "show_dev_menu", &show_dev_menu);
+    //(void) conf_get_b(bp_conf, "show_dev_menu", &show_dev_menu);
     (void) conf_get_str(bp_conf, "radio_device", &radio_dev);
     (void) conf_get_str(bp_conf, "sound_device", &sound_dev);
 
@@ -384,15 +383,11 @@ create_main_window(void) {
     checkbox_t *sound_out = sound_checkboxes_init(_("Sound output device"),
                                                   &buttons.sound_devs, &buttons.num_sound_devs,
                                                   &buttons.sound_boxes, &buttons.num_sound_boxes);
-    checkbox_t other[5] = {
+    checkbox_t other[4] = {
             {_("Miscellaneous"), NULL, NULL},
             {
              _("Auto disconnect when done"),
                     &buttons.disco_when_done, disco_when_done_tooltip
-            },
-            {
-             _("Show developer menu"),
-                    &buttons.show_dev_menu,   dev_menu_tooltip
             },
             {
              _("Hide default X-Plane 11 tug"),
@@ -401,8 +396,8 @@ create_main_window(void) {
             {NULL,               NULL, NULL}
     };
 
-    if (bp_xp_ver < 11000)
-        other[3] = (checkbox_t) {NULL, NULL, NULL};
+    if ((bp_xp_ver < 11000) || (bp_xp_ver >= 12000)) //Feature only for Xp11
+        other[2 ] = (checkbox_t) {NULL, NULL, NULL};
 
     col1_width = measure_checkboxes_width(col1);
     col2_width = measure_checkboxes_width(col2);
@@ -504,9 +499,9 @@ bp_conf_save(void) {
 
     if ((!file_exists(path, &isdir) || !isdir) &&
         !create_directory_recursive(path)) {
-        free(path);
         logMsg(BP_ERROR_LOG "error writing configuration: "
                             "can't create parent directory %s", path);
+        free(path);
         return (B_FALSE);
     }
     free(path);

--- a/src/cfg.c
+++ b/src/cfg.c
@@ -293,8 +293,8 @@ layout_checkboxes(checkbox_t *checkboxes, int x, int y, tooltip_set_t *tts) {
                                  width - (off_x - x), BUTTON_HEIGHT, 1,
                                  checkboxes[i].string, 0, main_win, xpWidgetClass_Caption);
         if (checkboxes[i].tooltip != NULL) {
-            UNUSED(tts);
-            tooltip_new(tts, x, y, CHECKBOX_SIZE + width, BUTTON_HEIGHT, _(checkboxes[i].tooltip));
+            tooltip_new(tts, x, y, CHECKBOX_SIZE + width,
+                        BUTTON_HEIGHT, _(checkboxes[i].tooltip));
         }
         y += BUTTON_HEIGHT;
     }
@@ -439,7 +439,7 @@ create_main_window(void) {
         buttons.var = create_widget_rel(x, y, B_FALSE, w, h, 1, \
             label, 0, main_win, xpWidgetClass_Button); \
         if (tooltip != NULL) { \
-         tooltip_new(tts, x, y, w, h, _(tooltip));  \
+         /*   tooltip_new(tts, x, y, w, h, _(tooltip));  */ \
         } \
     } while (0)
 
@@ -513,7 +513,7 @@ bp_conf_save(void) {
 
     path = mkpathname(CONF_DIRS, CONF_FILENAME, NULL);
     fp = fopen(path, "wb");
-    if (fp != NULL && conf_write(bp_conf, fp)) {
+    if (fp != NULL && (conf_write(bp_conf, fp) >= 0)) {
         logMsg(BP_INFO_LOG "Write config file %s", path);
         res = B_TRUE;
     } else {

--- a/src/xplane.c
+++ b/src/xplane.c
@@ -755,7 +755,7 @@ bp_priv_enable(void) {
 
     /* If the user OK'd it, remove the default tug */
     (void) conf_get_b(bp_conf, "dont_hide_xp11_tug", &dont_hide_xp_tug);
-    if (!dont_hide_xp_tug && bp_xp_ver >= 11000)
+    if ((!dont_hide_xp_tug) && (bp_xp_ver >= 11000) && (bp_xp_ver < 12000))
         set_xp11_tug_hidden(B_TRUE);
 
     inited = B_TRUE;


### PR DESCRIPTION
Some cleaning on the setup window

- dev menu option is no longer relevant as it was removed from the code a long time ago
- hide xp11 tug option appears only in Xp11. no need of confusing messages
- Log Error about the outline is changed to INFO , telling that the outline may not well drawn