### PR TITLE
feature: add Shared Flight support

### DIFF
--- a/src/bp.c
+++ b/src/bp.c
@@ -223,6 +223,10 @@ max_steer_angle(void) {
 static bool_t
 pbrake_is_set(void) {
     bool_t result;
+    
+    if(slave_mode && pb_set_override) 
+        return pb_set_remote;
+
     if (drs.pbrake_is_custom) {
         result = (dr_getf(&drs.pbrake) != 0);
     } else {

--- a/src/xplane.c
+++ b/src/xplane.c
@@ -57,15 +57,17 @@
 
 #define    STATUS_CHECK_INTVAL    1    /* second */
 enum {
-    SMARTCOPILOT_STATE_OFF = 0,    /* disconnected */
-    SMARTCOPILOT_STATE_SLAVE = 1,    /* connected and we're slave */
-    SMARTCOPILOT_STATE_MASTER = 2    /* connected and we're master */
+    COUPLED_STATE_OFF = 0,  /* disconnected */
+    COUPLED_STATE_SLAVE = 1,    /* connected and we're slave */
+    COUPLED_STATE_MASTER = 2,   /* connected and we're master */
+    COUPLED_STATE_PASSENGER = -1 /* connected and we're passenger */
 };
 
 static bool_t inited = B_FALSE;
 
 static XPLMCommandRef start_pb, stop_pb, start_cam, stop_cam, conn_first;
 static XPLMCommandRef cab_cam, recreate_routes;
+static XPLMCommandRef   abort_push;
 static XPLMMenuID root_menu;
 static int plugins_menu_item;
 static int start_pb_plan_menu_item, stop_pb_plan_menu_item;
@@ -86,6 +88,8 @@ static int cab_cam_handler(XPLMCommandRef, XPLMCommandPhase, void *);
 
 static int recreate_routes_handler(XPLMCommandRef, XPLMCommandPhase, void *);
 
+static int abort_push_handler(XPLMCommandRef, XPLMCommandPhase, void *);
+
 static bool_t start_after_cam = B_FALSE;
 
 static char xpdir[512];
@@ -95,6 +99,8 @@ const char *const bp_plugindir = plugindir;
 
 static bool_t smartcopilot_present;
 static dr_t smartcopilot_state;
+static bool_t sharedflight_present;
+static dr_t sharedflight_state; 
 
 int bp_xp_ver, bp_xplm_ver;
 XPLMHostApplicationID bp_host_id;
@@ -117,7 +123,8 @@ static XPLMFlightLoopID reload_floop_ID = NULL;
 
 /*
  * These datarefs are for syncing two instances of BetterPushback over the
- * net via syncing addons such as smartcopilot. This works as follows:
+ * net via syncing addons such as smartcopilot and Shared Flight. 
+ * This works as follows:
  * 1) Master/slave must not be switched during pushback (undefined behavior
  *	may result). It's possible to observe if BetterPushback is running by
  *	monitoring the read-only boolean "bp/started" dataref. This dataref
@@ -147,14 +154,19 @@ static XPLMFlightLoopID reload_floop_ID = NULL;
  *	There's no need to sync any other commands. The planning GUI is
  *	disabled on the slave machine and stopping of the pushback can only be
  *	performed by the master machine.
+  * 7) The dataref bp/parking_brake_override can be set to 1 on slaves and
+ *  then bp/parking_brake_set will be used instead of the local parking brake.
  */
 static dr_t bp_started_dr, bp_connected_dr, slave_mode_dr, op_complete_dr;
 static dr_t plan_complete_dr, bp_tug_name_dr;
+static dr_t pb_set_remote_dr, pb_set_override_dr;
 bool_t bp_started = B_FALSE;
 bool_t bp_connected = B_FALSE;
 bool_t slave_mode = B_FALSE;
 bool_t op_complete = B_FALSE;
 bool_t plan_complete = B_FALSE;
+bool_t pb_set_remote = B_FALSE;
+bool_t pb_set_override = B_FALSE;
 char bp_tug_name[64] = {0};
 
 /*
@@ -448,28 +460,46 @@ bp_get_lang(void) {
     return (acfutils_xplang2code(XPLMGetLanguage()));
 }
 
+static void
+coupled_state_change()
+{
+    /* If we were in slave mode, reenable the menu items. */
+    XPLMEnableMenuItem(root_menu, start_pb_menu_item, slave_mode ? 1 : 0);
+    XPLMEnableMenuItem(root_menu, start_pb_plan_menu_item, slave_mode ? 1 : 0);
+
+    XPLMEnableMenuItem(root_menu, stop_pb_menu_item, B_FALSE);
+    XPLMEnableMenuItem(root_menu, stop_pb_plan_menu_item, B_FALSE);
+}
+
 void
 slave_mode_cb(dr_t *dr, void *unused) {
     UNUSED(unused);
     UNUSED(dr);
     VERIFY(!bp_started);
 
-    if (slave_mode) {
-        bp_fini();
-        XPLMEnableMenuItem(root_menu, start_pb_menu_item, B_FALSE);
-        XPLMEnableMenuItem(root_menu, stop_pb_menu_item, B_FALSE);
-        XPLMEnableMenuItem(root_menu, start_pb_plan_menu_item, B_FALSE);
-        XPLMEnableMenuItem(root_menu, stop_pb_plan_menu_item, B_FALSE);
-    } else {
-        XPLMEnableMenuItem(root_menu, start_pb_menu_item, B_TRUE);
-        XPLMEnableMenuItem(root_menu, stop_pb_menu_item, B_FALSE);
-        XPLMEnableMenuItem(root_menu, start_pb_plan_menu_item, B_TRUE);
-        XPLMEnableMenuItem(root_menu, stop_pb_plan_menu_item, B_FALSE);
-    }
+    if (slave_mode) bp_fini();
+
+    coupled_state_change();
+}
+
+void
+pb_set_remote_cb(dr_t *dr, void *unused)
+{
+    UNUSED(unused);
+    UNUSED(dr);
+
+}
+
+void
+pb_set_override_cb(dr_t *dr, void *unused)
+{
+    UNUSED(unused);
+    UNUSED(dr);
 }
 
 static float
-status_check(float elapsed, float elapsed2, int counter, void *refcon) {
+status_check(float elapsed, float elapsed2, int counter, void *refcon)
+{
     UNUSED(elapsed);
     UNUSED(elapsed2);
     UNUSED(counter);
@@ -477,15 +507,16 @@ status_check(float elapsed, float elapsed2, int counter, void *refcon) {
 
     XPLMEnableMenuItem(root_menu, cab_cam_menu_item, cab_view_can_start());
 
-    if (!smartcopilot_present)
+    // Status check only needed if we have a known system of coupling installed...
+    if (!smartcopilot_present && !sharedflight_present)
         return (1);
 
-    if (dr_geti(&smartcopilot_state) == SMARTCOPILOT_STATE_SLAVE &&
+    if (smartcopilot_present && dr_geti(&smartcopilot_state) == COUPLED_STATE_SLAVE &&
         !slave_mode) {
         if (bp_started) {
             XPLMSpeakString(_("Pushback failure: smartcopilot "
-                              "attempted to switch master/slave or network "
-                              "connection lost. Stopping operation."));
+                "attempted to switch master/slave or network "
+                "connection lost. Stopping operation."));
         }
         /*
          * If we were in master mode, stop the camera, flush out all
@@ -493,25 +524,40 @@ status_check(float elapsed, float elapsed2, int counter, void *refcon) {
          * will control us.
          */
         bp_fini();
-        XPLMEnableMenuItem(root_menu, start_pb_menu_item, B_FALSE);
-        XPLMEnableMenuItem(root_menu, stop_pb_menu_item, B_FALSE);
-        XPLMEnableMenuItem(root_menu, start_pb_plan_menu_item, B_FALSE);
-        XPLMEnableMenuItem(root_menu, stop_pb_plan_menu_item, B_FALSE);
         slave_mode = B_TRUE;
-    } else if (dr_geti(&smartcopilot_state) != SMARTCOPILOT_STATE_SLAVE &&
-               slave_mode) {
+        coupled_state_change();
+    } else if (sharedflight_present && dr_geti(&sharedflight_state) == COUPLED_STATE_SLAVE &&
+        !slave_mode) {
+        if (bp_started) {
+            XPLMSpeakString(_("Pushback failure: Shared Flight "
+                "attempted to switch pilot flying or network "
+                "connection lost. Stopping operation."));
+        }
+        bp_fini();
+        slave_mode = B_TRUE;
+        coupled_state_change();
+    } else if ((smartcopilot_present && dr_geti(&smartcopilot_state) != COUPLED_STATE_SLAVE) &&
+        (!sharedflight_present || dr_geti(&sharedflight_state) != COUPLED_STATE_SLAVE) &&
+        slave_mode) {
         if (bp_started) {
             XPLMSpeakString(_("Pushback failure: smartcopilot "
-                              "attempted to switch master/slave or network "
-                              "connection lost. Stopping operation."));
+                "attempted to switch master/slave or network "
+                "connection lost. Stopping operation."));
         }
-        /* If we were in slave mode, reenable the menu items. */
         bp_fini();
-        XPLMEnableMenuItem(root_menu, start_pb_menu_item, B_TRUE);
-        XPLMEnableMenuItem(root_menu, stop_pb_menu_item, B_FALSE);
-        XPLMEnableMenuItem(root_menu, start_pb_plan_menu_item, B_TRUE);
-        XPLMEnableMenuItem(root_menu, stop_pb_plan_menu_item, B_FALSE);
         slave_mode = B_FALSE;
+        coupled_state_change();
+    } else if ((sharedflight_present && dr_geti(&sharedflight_state) != COUPLED_STATE_SLAVE && dr_geti(&sharedflight_state) != COUPLED_STATE_PASSENGER) &&
+        (!smartcopilot_present || dr_geti(&smartcopilot_state) != COUPLED_STATE_SLAVE) &&
+        slave_mode) {
+        if (bp_started) {
+            XPLMSpeakString(_("Pushback failure: Shared Flight "
+                "attempted to switch pilot flying or network "
+                "connection lost. Stopping operation."));
+        }
+        bp_fini();
+        slave_mode = B_FALSE;
+        coupled_state_change();
     }
 
     return (STATUS_CHECK_INTVAL);
@@ -609,6 +655,9 @@ XPluginStart(char *name, char *sig, char *desc) {
             "BetterPushback/recreate_scenery_routes",
             _("Recreate scenery routes from WED files."));
 
+    abort_push = XPLMCreateCommand("BetterPushback/abort_push",
+        _("Abort pushback during coupled push"));
+
     bp_boot_init();
 
     dr_create_i(&bp_started_dr, (int *) &bp_started, B_FALSE,
@@ -624,6 +673,13 @@ XPluginStart(char *name, char *sig, char *desc) {
                 "bp/plan_complete");
     dr_create_b(&bp_tug_name_dr, bp_tug_name, sizeof(bp_tug_name),
                 B_TRUE, "bp/tug_name");
+
+    dr_create_i(&pb_set_remote_dr, (int *)&pb_set_remote, B_FALSE,
+        "bp/parking_brake_set");
+    pb_set_remote_dr.write_cb = pb_set_remote_cb;
+    dr_create_i(&pb_set_override_dr, (int *)&pb_set_override, B_FALSE,
+        "bp/parking_brake_override");
+    pb_set_override_dr.write_cb = pb_set_override_cb;
 
     XPLMGetVersions(&bp_xp_ver, &bp_xplm_ver, &bp_host_id);
 
@@ -642,6 +698,8 @@ XPluginStop(void) {
     dr_delete(&slave_mode_dr);
     dr_delete(&op_complete_dr);
     dr_delete(&bp_tug_name_dr);
+    dr_delete(&pb_set_remote_dr);
+    dr_delete(&pb_set_override_dr);
     dcr_fini();
 
     if (reload_floop_ID != NULL) {
@@ -678,6 +736,8 @@ XPluginReceiveMessage(XPLMPluginID from, int msg, void *param) {
             /* Force a reinit to re-read aircraft size params */
             smartcopilot_present = dr_find(&smartcopilot_state, "scp/api/ismaster");
             stop_cam_handler(NULL, xplm_CommandEnd, NULL);
+            sharedflight_present = dr_find(&sharedflight_state,
+            "SharedFlight/is_pilot_flying");
             bp_fini();
             cab_view_fini();
 #ifndef    SLAVE_DEBUG
@@ -726,6 +786,7 @@ bp_priv_enable(void) {
     XPLMRegisterCommandHandler(cab_cam, cab_cam_handler, 1, NULL);
     XPLMRegisterCommandHandler(recreate_routes, recreate_routes_handler,
                                1, NULL);
+    XPLMRegisterCommandHandler(abort_push, abort_push_handler, 1, NULL);
 
     plugins_menu_item = XPLMAppendMenuItem(XPLMFindPluginsMenu(),
                                            "Better Pushback", NULL, 1);
@@ -827,6 +888,21 @@ bp_sched_reload(void) {
     reload_rqst = B_TRUE;
     ASSERT(reload_floop_ID != NULL);
     XPLMScheduleFlightLoop(reload_floop_ID, -1, 1);
+}
+
+static int
+abort_push_handler(XPLMCommandRef cmd, XPLMCommandPhase phase,
+    void *refcon)
+{
+    UNUSED(cmd);
+    UNUSED(refcon);
+    if (phase != xplm_CommandEnd)
+        return (0);
+    bp_fini();
+    logMsg("bp_fini called from abort_push_handler, bp_started = %d", bp_started);
+    slave_mode = B_FALSE;
+    coupled_state_change(); 
+    return (1);
 }
 
 #if    IBM

--- a/src/xplane.h
+++ b/src/xplane.h
@@ -38,6 +38,8 @@ extern const char *const bp_plugindir;
 extern bool_t bp_started;
 extern bool_t bp_connected;
 extern bool_t slave_mode;
+extern bool_t pb_set_remote;
+extern bool_t pb_set_override;
 extern bool_t op_complete;
 extern bool_t plan_complete;
 extern char bp_tug_name[64];


### PR DESCRIPTION
Merging this would enable me to no longer worry about shipping a separate Shared Flight supported build of BetterPushbackC (which has had an open pull request with these changes for years).     Thanks very much for your consideration!

This adds awareness of Shared Flight dataref for detection of Shared Flight presence and state in a parallel fashion to SmartCopilot detection which was already present in the code.   After this change either addon for shared cockpit flying within X-Plane wil be supported.

If you need access to Shared Flight plugin for testing this please let me know.

Cheers,
Justin