### PR TITLE
Improve the planner in multi-monitor config

### DIFF
--- a/src/cfg.h
+++ b/src/cfg.h
@@ -25,6 +25,15 @@
 extern "C" {
 #endif
 
+typedef struct {
+    bool_t planner_running;
+    float fov_h_deg;
+    float fov_h_ratio;
+    float fov_roll;
+    float fov_v_deg;
+    float fov_v_ratio;
+} fov_t;
+
 extern conf_t *bp_conf;
 
 bool_t bp_conf_init();
@@ -40,6 +49,10 @@ void bp_conf_open(void);
 bool_t conf_get_disco_when_done(char *my_acf, bool_t *value);
 
 void conf_set_disco_when_done(char *my_acf, bool_t value);
+
+void push_reset_fov_values(void);
+
+void pop_fov_values(void);
 
 #ifdef    __cplusplus
 }


### PR DESCRIPTION
1- fix the planner on Xp12 (only) with multiple screen. The mouse was not following the outline of the aircraft.
2- Temporary clear the lateral offsets while the planner is running to avoid shift between the aircraft and the drawing. The settings are restored when exiting the planner or x-plane 