### PR TITLE
avoid pref window to interfere in the planner

### DIFF
--- a/src/cfg.c
+++ b/src/cfg.c
@@ -233,6 +233,7 @@ main_window_cb(XPWidgetMessage msg, XPWidgetID widget, intptr_t param1,
     UNUSED(param2);
 
     if (msg == xpMessage_CloseButtonPushed && widget == main_win) {
+        set_pref_widget_status(B_FALSE);
         XPHideWidget(main_win);
         return (1);
     } else if (msg == xpMsg_PushButtonPressed) {
@@ -659,6 +660,7 @@ bp_conf_open(void) {
     else
         buttons_update(); // again here as we may change to another aircraft without relauching X-plane
     XPShowWidget(main_win);
+    set_pref_widget_status(B_TRUE);
 }
 
 

--- a/src/xplane.h
+++ b/src/xplane.h
@@ -77,6 +77,10 @@ const char *bp_get_lang(void);
 
 void bp_sched_reload(void);
 
+bool_t get_pref_widget_status(void);
+
+void set_pref_widget_status(bool_t active);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Preference window loose the focus if activated during the planner or during the pushback itself.
This fix blocks the pref window to appears during the pushback or planner. 
and the opposite : pushback or planner is blocked during the display of the pref window