### PR TITLE
Some fixes for the "connect tug first" procedure

### DIFF
--- a/src/xplane.c
+++ b/src/xplane.c
@@ -275,10 +275,13 @@ start_pb_handler(XPLMCommandRef cmd, XPLMCommandPhase phase, void *refcon) {
     if (get_pref_widget_status()) // do nothing if preference widget is active
         return (1);
 
-    XPLMCommandOnce(stop_cam);
+    stop_cam_handler(NULL, xplm_CommandEnd, NULL);     // synchronously stop a possible open cam
+
     if (!bp_init())
         return (1);
-    if (bp_num_segs() == 0 && !slave_mode) {
+
+    // if late_plan_requested always present plan for final review
+    if ((late_plan_requested || bp_num_segs() == 0) && !slave_mode) {
         if (!bp_cam_start())
             return (1);
         XPLMEnableMenuItem(root_menu, prefs_menu_item, B_FALSE);
@@ -395,6 +398,7 @@ conn_first_handler(XPLMCommandRef cmd, XPLMCommandPhase phase, void *refcon) {
 
     late_plan_requested = B_TRUE;
     (void) bp_cam_stop();
+    bp_delete_all_segs();       // so we will always present the route for review before start
     if (!bp_start())
         return (1);
 


### PR DESCRIPTION
The value of the "connect tug first" procedure (e.g. on VATSIM) is that you are ready to go but have a chance to make last second changes in case you get a different route.
Prior to these patches a preplanned route was not presented for final review.

As future steps I plan:
- add "connect tug first" to the menu
- guard direct command invocation against invalid or double invocation like the menu entries that are enabled/disabled accordingly   