### PR TITLE
always normalize external hdg values before using them

### DIFF
--- a/src/bp.c
+++ b/src/bp.c
@@ -438,7 +438,7 @@ bp_gather(void) {
      */
     bp.cur_pos.pos = VECT2(dr_getf(&drs.local_x),
                            -dr_getf(&drs.local_z));
-    bp.cur_pos.hdg = dr_getf(&drs.hdg);
+    bp.cur_pos.hdg = normalize_hdg(dr_getf(&drs.hdg));
     bp.cur_pos.spd = vect2_dotprod(hdg2dir(bp.cur_pos.hdg),
                                    VECT2(dr_getf(&drs.local_vx), -dr_getf(&drs.local_vz)));
     bp.cur_t = dr_getf(&drs.sim_time);


### PR DESCRIPTION
I searched through all assignments to bp.{cur|last}_pos and the dataref seems to be the culprit. I know from my AutoDGS plugin that some old airports have unnormalized ramp headings that lead to crashes in libacfutils as well.